### PR TITLE
refactor(test): extract data generators to shared TestUtilities project

### DIFF
--- a/.idea/.idea.Reward_Flow_v2/.idea/workspace.xml
+++ b/.idea/.idea.Reward_Flow_v2/.idea/workspace.xml
@@ -10,11 +10,31 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="122934b0-07bf-4213-8299-df7b9ea03e04" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Users/GetAllUsersTests.cs" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Users/GetUserByEmailTests.cs" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Users/GetUserByUsernameTests.cs" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/RewardFlow.TestUtilities/RewardFlow.TestUtilities.csproj" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/.idea.Reward_Flow_v2/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.Reward_Flow_v2/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/RewardFlow.API/User/AuthApiPath.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/RewardFlow.API/User/AuthApiPath.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Reward_Flow_v2.slnx" beforeDir="false" afterPath="$PROJECT_DIR$/Reward_Flow_v2.slnx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Auth/LoginTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Auth/LoginTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Auth/RegisterTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Auth/RegisterTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Auth/ResetPasswordTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Auth/ResetPasswordTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Auth/UserFullLifecycleTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Auth/UserFullLifecycleTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Employees/BulkOperations/BulkCreateTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Employees/BulkOperations/BulkCreateTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Employees/BulkOperations/BulkDeleteTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Employees/BulkOperations/BulkDeleteTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Employees/BulkOperations/BulkUpdateTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Employees/BulkOperations/BulkUpdateTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Employees/CreateEmployeeTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Employees/CreateEmployeeTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Employees/DeleteEmployeeTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Employees/DeleteEmployeeTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Employees/EmployeeFullLifecycleTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Employees/EmployeeFullLifecycleTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Employees/EmployeeSearchTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Employees/EmployeeSearchTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Employees/GetEmployeeTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Employees/GetEmployeeTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Employees/UpdateEmployeeTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Employees/UpdateEmployeeTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Infrastructure/DataGenerators/Fakers/Employees/EmployeeFaker.cs" beforeDir="false" afterPath="$PROJECT_DIR$/RewardFlow.TestUtilities/DataGenerators/Fakers/Employees/EmployeeFaker.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Infrastructure/DataGenerators/Fakers/Employees/EmployeeFields.cs" beforeDir="false" afterPath="$PROJECT_DIR$/RewardFlow.TestUtilities/DataGenerators/Fakers/Employees/EmployeeFields.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Infrastructure/DataGenerators/Fakers/Users/UserFaker.cs" beforeDir="false" afterPath="$PROJECT_DIR$/RewardFlow.TestUtilities/DataGenerators/Fakers/Users/UserFaker.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Infrastructure/DataGenerators/Fakers/Users/UserFields.cs" beforeDir="false" afterPath="$PROJECT_DIR$/RewardFlow.TestUtilities/DataGenerators/Fakers/Users/UserFields.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Infrastructure/DataGenerators/TestDataGenerator.cs" beforeDir="false" afterPath="$PROJECT_DIR$/RewardFlow.TestUtilities/DataGenerators/TestDataGenerator.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/RewardFlow.IntegrationTests.csproj" beforeDir="false" afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/RewardFlow.IntegrationTests.csproj" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Users/GetAllUsersTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Users/GetAllUsersTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Users/GetUserByEmailTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Users/GetUserByEmailTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Users/GetUserByUsernameTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Users/GetUserByUsernameTests.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -38,6 +58,11 @@
         </map>
       </branch-storage>
     </favorite-branches>
+    <option name="RECENT_BRANCH_BY_REPOSITORY">
+      <map>
+        <entry key="$PROJECT_DIR$" value="test/employee-unit-tests" />
+      </map>
+    </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
   </component>
   <component name="GitHubPullRequestSearchHistory">{
@@ -72,6 +97,9 @@
     <setting file="file://$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Infrastructure/User/UserTestFixture.cs" root0="FORCE_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Users/GetAllUsersTests.cs" root0="FORCE_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Users/GetUserByEmailTests.cs" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/src/RewardFlow.UnitTest/Employees/CreateEmployeeTest.cs" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/src/RewardFlow.UnitTest/Employees/EmployeeTestFixture.cs" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/src/RewardFlow.UnitTest/Employees/TestWebApplicationFactory.cs" root0="FORCE_HIGHLIGHTING" />
   </component>
   <component name="MetaFilesCheckinStateConfiguration" checkMetaFiles="true" />
   <component name="ProblemsViewState">
@@ -85,35 +113,35 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;.NET Launch Settings Profile.RewardFlow.API: https.executor&quot;: &quot;Run&quot;,
-    &quot;5921cb4c-4439-4b1b-8e8e-8ed8576ac015.executor&quot;: &quot;Debug&quot;,
-    &quot;6a995ea2-adb3-462a-8026-c33d164c2970.executor&quot;: &quot;Debug&quot;,
-    &quot;ATTACH_DIALOG_SELECTED_CONTAINER&quot;: &quot;sqlserver-reward-flow-debug&quot;,
-    &quot;Docker.deploy/docker-compose.debug.yaml.migrate: Compose Deployment.executor&quot;: &quot;Run&quot;,
-    &quot;Docker.deploy/docker-compose.debug.yaml.sqlserver: Compose Deployment.executor&quot;: &quot;Run&quot;,
-    &quot;Docker.deploy/docker-compose.debug.yaml: Compose Deployment.executor&quot;: &quot;Run&quot;,
-    &quot;Docker.deploy/docker-compose.dev.yaml: Compose Deployment.executor&quot;: &quot;Run&quot;,
-    &quot;Docker.deploy/docker-compose.yaml: Compose Deployment.executor&quot;: &quot;Run&quot;,
-    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.typescript.service.memoryLimit.init&quot;: &quot;true&quot;,
-    &quot;bedb83f7-5580-48af-9bc0-9ed41d22201e.executor&quot;: &quot;Debug&quot;,
-    &quot;c8ba7720-7892-481e-a505-58df8f6921a3.executor&quot;: &quot;Debug&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;test/user-integration-tests&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/media/ahmed/54d07f6a-5b2f-4c8f-a919-c812fce84cab/Projects/Reward_Flow_v2/deploy/docker-compose.dev.yaml&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;reference.settings.project.statistic.project.settings&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    ".NET Launch Settings Profile.RewardFlow.API: https.executor": "Run",
+    "5921cb4c-4439-4b1b-8e8e-8ed8576ac015.executor": "Debug",
+    "6a995ea2-adb3-462a-8026-c33d164c2970.executor": "Debug",
+    "ATTACH_DIALOG_SELECTED_CONTAINER": "sqlserver-reward-flow-debug",
+    "Docker.deploy/docker-compose.debug.yaml.migrate: Compose Deployment.executor": "Run",
+    "Docker.deploy/docker-compose.debug.yaml.sqlserver: Compose Deployment.executor": "Run",
+    "Docker.deploy/docker-compose.debug.yaml: Compose Deployment.executor": "Run",
+    "Docker.deploy/docker-compose.dev.yaml: Compose Deployment.executor": "Run",
+    "Docker.deploy/docker-compose.yaml: Compose Deployment.executor": "Run",
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
+    "bedb83f7-5580-48af-9bc0-9ed41d22201e.executor": "Debug",
+    "c8ba7720-7892-481e-a505-58df8f6921a3.executor": "Debug",
+    "git-widget-placeholder": "test/create-test-utilities-project",
+    "last_opened_file_path": "/media/ahmed/54d07f6a-5b2f-4c8f-a919-c812fce84cab/Projects/Reward_Flow_v2/deploy/docker-compose.dev.yaml",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "reference.settings.project.statistic.project.settings",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
   <component name="RunManager" selected="Docker.deploy/docker-compose.dev.yaml: Compose Deployment">
     <configuration name="RewardFlow.API: http" type="LaunchSettings" factoryName=".NET Launch Settings Profile">
       <option name="LAUNCH_PROFILE_PROJECT_FILE_PATH" value="$PROJECT_DIR$/src/RewardFlow.API/RewardFlow.API.csproj" />
@@ -238,11 +266,11 @@
     </configuration>
     <recent_temporary>
       <list>
+        <item itemvalue="Docker.deploy/docker-compose.yaml: Compose Deployment" />
         <item itemvalue="Docker.deploy/docker-compose.dev.yaml: Compose Deployment" />
         <item itemvalue="Docker.deploy/docker-compose.debug.yaml: Compose Deployment" />
         <item itemvalue="Docker.deploy/docker-compose.debug.yaml.sqlserver: Compose Deployment" />
         <item itemvalue="Docker.deploy/docker-compose.debug.yaml.migrate: Compose Deployment" />
-        <item itemvalue="Docker.deploy/docker-compose.yaml: Compose Deployment" />
       </list>
     </recent_temporary>
   </component>
@@ -469,10 +497,10 @@
           <line>58</line>
           <properties documentPath="$PROJECT_DIR$/src/RewardFlow.IntegrationTests/Auth/LoginTests.cs" containingFunctionPresentation="Method 'Login_WithValidCredentials_ShouldReturnOk'">
             <startOffsets>
-              <option value="1997" />
+              <option value="1979" />
             </startOffsets>
             <endOffsets>
-              <option value="2041" />
+              <option value="2023" />
             </endOffsets>
           </properties>
           <option name="timeStamp" value="69" />

--- a/RewardFlow.TestUtilities/DataGenerators/Fakers/Employees/EmployeeFaker.cs
+++ b/RewardFlow.TestUtilities/DataGenerators/Fakers/Employees/EmployeeFaker.cs
@@ -2,7 +2,7 @@ using Bogus;
 using Reward_Flow_v2.Employees.Data;
 using System.Linq.Expressions;
 
-namespace RewardFlow.IntegrationTests.Infrastructure.DataGenerators.Fakers.Employees;
+namespace RewardFlow.TestUtilities.DataGenerators.Fakers.Employees;
 
 public class EmployeeFaker : Faker<Employee>
 {

--- a/RewardFlow.TestUtilities/DataGenerators/Fakers/Employees/EmployeeFields.cs
+++ b/RewardFlow.TestUtilities/DataGenerators/Fakers/Employees/EmployeeFields.cs
@@ -1,4 +1,4 @@
-namespace RewardFlow.IntegrationTests.Infrastructure.DataGenerators.Fakers.Employees;
+namespace RewardFlow.TestUtilities.DataGenerators.Fakers.Employees;
 
 [Flags]
 public enum EmployeeFields

--- a/RewardFlow.TestUtilities/DataGenerators/Fakers/Users/UserFaker.cs
+++ b/RewardFlow.TestUtilities/DataGenerators/Fakers/Users/UserFaker.cs
@@ -2,7 +2,7 @@ using Bogus;
 using Reward_Flow_v2.User.Data;
 using System.Linq.Expressions;
 
-namespace RewardFlow.IntegrationTests.Infrastructure.DataGenerators.Fakers.Users;
+namespace RewardFlow.TestUtilities.DataGenerators.Fakers.Users;
 
 /// <summary>
 /// Generates fake user data for testing purposes, inheriting from <see cref="Faker{T}"/>.

--- a/RewardFlow.TestUtilities/DataGenerators/Fakers/Users/UserFields.cs
+++ b/RewardFlow.TestUtilities/DataGenerators/Fakers/Users/UserFields.cs
@@ -1,4 +1,4 @@
-namespace RewardFlow.IntegrationTests.Infrastructure.DataGenerators.Fakers.Users;
+namespace RewardFlow.TestUtilities.DataGenerators.Fakers.Users;
 
 [Flags]
 public enum UserFields

--- a/RewardFlow.TestUtilities/DataGenerators/TestDataGenerator.cs
+++ b/RewardFlow.TestUtilities/DataGenerators/TestDataGenerator.cs
@@ -1,7 +1,7 @@
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators.Fakers.Employees;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators.Fakers.Users;
+using RewardFlow.TestUtilities.DataGenerators.Fakers.Employees;
+using RewardFlow.TestUtilities.DataGenerators.Fakers.Users;
 
-namespace RewardFlow.IntegrationTests.Infrastructure.DataGenerators;
+namespace RewardFlow.TestUtilities.DataGenerators;
 
 public class TestDataGenerator
 {

--- a/RewardFlow.TestUtilities/RewardFlow.TestUtilities.csproj
+++ b/RewardFlow.TestUtilities/RewardFlow.TestUtilities.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\src\RewardFlow.API\RewardFlow.API.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Bogus" Version="35.6.5" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Database\" />
+    </ItemGroup>
+
+</Project>

--- a/Reward_Flow_v2.slnx
+++ b/Reward_Flow_v2.slnx
@@ -5,6 +5,7 @@
     <File Path="deploy\docker-compose.yaml" />
     <File Path="README.md" />
   </Folder>
+  <Project Path="RewardFlow.TestUtilities/RewardFlow.TestUtilities.csproj" />
   <Project Path="src/RewardFlow.API/RewardFlow.API.csproj" />
   <Project Path="src/RewardFlow.IntegrationTests/RewardFlow.IntegrationTests.csproj" />
   <Project Path="src/RewardFlow.UnitTest/RewardFlow.UnitTest.csproj" />

--- a/src/RewardFlow.IntegrationTests/Auth/LoginTests.cs
+++ b/src/RewardFlow.IntegrationTests/Auth/LoginTests.cs
@@ -3,10 +3,10 @@ using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
 using RewardFlow.IntegrationTests.Infrastructure;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators;
 using RewardFlow.IntegrationTests.Auth.Common;
 using Reward_Flow_v2.User.AuthService.Login;
 using Reward_Flow_v2.User.AuthService.Register;
+using RewardFlow.TestUtilities.DataGenerators;
 using Xunit;
 
 namespace RewardFlow.IntegrationTests.Auth;

--- a/src/RewardFlow.IntegrationTests/Auth/RegisterTests.cs
+++ b/src/RewardFlow.IntegrationTests/Auth/RegisterTests.cs
@@ -4,10 +4,10 @@ using System.Net.Http.Json;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using RewardFlow.IntegrationTests.Infrastructure;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators;
 using RewardFlow.IntegrationTests.Auth.Common;
 using Reward_Flow_v2.User.AuthService.Register;
 using Reward_Flow_v2.User.Data;
+using RewardFlow.TestUtilities.DataGenerators;
 using Xunit;
 
 namespace RewardFlow.IntegrationTests.Auth;

--- a/src/RewardFlow.IntegrationTests/Auth/ResetPasswordTests.cs
+++ b/src/RewardFlow.IntegrationTests/Auth/ResetPasswordTests.cs
@@ -3,11 +3,11 @@ using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
 using RewardFlow.IntegrationTests.Infrastructure;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators;
 using RewardFlow.IntegrationTests.Auth.Common;
 using Reward_Flow_v2.User;
 using Reward_Flow_v2.User.Data;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators.Fakers.Users;
+using RewardFlow.TestUtilities.DataGenerators;
+using RewardFlow.TestUtilities.DataGenerators.Fakers.Users;
 using Xunit;
 
 namespace RewardFlow.IntegrationTests.Auth;

--- a/src/RewardFlow.IntegrationTests/Auth/UserFullLifecycleTests.cs
+++ b/src/RewardFlow.IntegrationTests/Auth/UserFullLifecycleTests.cs
@@ -3,12 +3,12 @@ using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
 using RewardFlow.IntegrationTests.Infrastructure;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators;
 using RewardFlow.IntegrationTests.Auth.Common;
 using Reward_Flow_v2.User;
 using Reward_Flow_v2.User.AuthService.Register;
 using Reward_Flow_v2.User.AuthService.Login;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators.Fakers.Users;
+using RewardFlow.TestUtilities.DataGenerators;
+using RewardFlow.TestUtilities.DataGenerators.Fakers.Users;
 using Xunit;
 
 namespace RewardFlow.IntegrationTests.Auth;

--- a/src/RewardFlow.IntegrationTests/Employees/BulkOperations/BulkCreateTests.cs
+++ b/src/RewardFlow.IntegrationTests/Employees/BulkOperations/BulkCreateTests.cs
@@ -4,11 +4,11 @@ using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using RewardFlow.IntegrationTests.Infrastructure;
 using Reward_Flow_v2.Employees.Data;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators;
 using Reward_Flow_v2.Employees.CreateEmployee;
 using Reward_Flow_v2.Employees.BulkInsertEmployees;
 using RewardFlow.IntegrationTests.Employees.Common;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators.Fakers.Employees;
+using RewardFlow.TestUtilities.DataGenerators;
+using RewardFlow.TestUtilities.DataGenerators.Fakers.Employees;
 using Xunit;
 
 namespace RewardFlow.IntegrationTests.Employees.BulkOperations;

--- a/src/RewardFlow.IntegrationTests/Employees/BulkOperations/BulkDeleteTests.cs
+++ b/src/RewardFlow.IntegrationTests/Employees/BulkOperations/BulkDeleteTests.cs
@@ -4,10 +4,10 @@ using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using RewardFlow.IntegrationTests.Infrastructure;
 using Reward_Flow_v2.Employees.Data;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators;
 using Reward_Flow_v2.Employees.CreateEmployee;
 using Reward_Flow_v2.Employees.BulkInsertEmployees;
 using RewardFlow.IntegrationTests.Employees.Common;
+using RewardFlow.TestUtilities.DataGenerators;
 using Xunit;
 
 namespace RewardFlow.IntegrationTests.Employees.BulkOperations;

--- a/src/RewardFlow.IntegrationTests/Employees/BulkOperations/BulkUpdateTests.cs
+++ b/src/RewardFlow.IntegrationTests/Employees/BulkOperations/BulkUpdateTests.cs
@@ -4,11 +4,11 @@ using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using RewardFlow.IntegrationTests.Infrastructure;
 using Reward_Flow_v2.Employees.Data;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators;
 using Reward_Flow_v2.Employees.CreateEmployee;
 using Reward_Flow_v2.Employees.BulkInsertEmployees;
 using Reward_Flow_v2.Employees.UpdateEmployee;
 using RewardFlow.IntegrationTests.Employees.Common;
+using RewardFlow.TestUtilities.DataGenerators;
 using Xunit;
 
 namespace RewardFlow.IntegrationTests.Employees.BulkOperations;

--- a/src/RewardFlow.IntegrationTests/Employees/CreateEmployeeTests.cs
+++ b/src/RewardFlow.IntegrationTests/Employees/CreateEmployeeTests.cs
@@ -8,8 +8,8 @@ using Reward_Flow_v2.Employees.CreateEmployee;
 using RewardFlow.IntegrationTests.Infrastructure;
 using Reward_Flow_v2.Employees.Data;
 using RewardFlow.IntegrationTests.Employees.Common;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators.Fakers.Employees;
+using RewardFlow.TestUtilities.DataGenerators;
+using RewardFlow.TestUtilities.DataGenerators.Fakers.Employees;
 using Xunit;
 
 namespace RewardFlow.IntegrationTests.Employees;

--- a/src/RewardFlow.IntegrationTests/Employees/DeleteEmployeeTests.cs
+++ b/src/RewardFlow.IntegrationTests/Employees/DeleteEmployeeTests.cs
@@ -2,9 +2,9 @@ using System.Net;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using RewardFlow.IntegrationTests.Infrastructure;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators;
 using Reward_Flow_v2.Employees.Data;
 using RewardFlow.IntegrationTests.Employees.Common;
+using RewardFlow.TestUtilities.DataGenerators;
 using Xunit;
 
 namespace RewardFlow.IntegrationTests.Employees;

--- a/src/RewardFlow.IntegrationTests/Employees/EmployeeFullLifecycleTests.cs
+++ b/src/RewardFlow.IntegrationTests/Employees/EmployeeFullLifecycleTests.cs
@@ -9,7 +9,7 @@ using Reward_Flow_v2.Employees.UpdateEmployee;
 using RewardFlow.IntegrationTests.Infrastructure;
 using Reward_Flow_v2.Employees.Data;
 using RewardFlow.IntegrationTests.Employees.Common;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators;
+using RewardFlow.TestUtilities.DataGenerators;
 using Xunit;
 
 namespace RewardFlow.IntegrationTests.Employees;

--- a/src/RewardFlow.IntegrationTests/Employees/EmployeeSearchTests.cs
+++ b/src/RewardFlow.IntegrationTests/Employees/EmployeeSearchTests.cs
@@ -4,7 +4,7 @@ using Reward_Flow_v2.Employees.CreateEmployee;
 using Reward_Flow_v2.Employees.Data;
 using RewardFlow.IntegrationTests.Employees.Common;
 using RewardFlow.IntegrationTests.Infrastructure;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators;
+using RewardFlow.TestUtilities.DataGenerators;
 using System.Net;
 using System.Net.Http.Json;
 using Xunit;

--- a/src/RewardFlow.IntegrationTests/Employees/GetEmployeeTests.cs
+++ b/src/RewardFlow.IntegrationTests/Employees/GetEmployeeTests.cs
@@ -3,8 +3,8 @@ using System.Net.Http.Json;
 using FluentAssertions;
 using RewardFlow.IntegrationTests.Infrastructure;
 using Reward_Flow_v2.Employees.Data;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators.Fakers.Employees;
+using RewardFlow.TestUtilities.DataGenerators;
+using RewardFlow.TestUtilities.DataGenerators.Fakers.Employees;
 using Xunit;
 
 namespace RewardFlow.IntegrationTests.Employees;

--- a/src/RewardFlow.IntegrationTests/Employees/UpdateEmployeeTests.cs
+++ b/src/RewardFlow.IntegrationTests/Employees/UpdateEmployeeTests.cs
@@ -7,7 +7,7 @@ using RewardFlow.IntegrationTests.Infrastructure;
 using Reward_Flow_v2.Employees.Data;
 using Reward_Flow_v2.Employees.UpdateEmployee;
 using RewardFlow.IntegrationTests.Employees.Common;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators;
+using RewardFlow.TestUtilities.DataGenerators;
 using System.Reflection;
 using Xunit;
 

--- a/src/RewardFlow.IntegrationTests/RewardFlow.IntegrationTests.csproj
+++ b/src/RewardFlow.IntegrationTests/RewardFlow.IntegrationTests.csproj
@@ -27,10 +27,13 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\RewardFlow.TestUtilities\RewardFlow.TestUtilities.csproj" />
       <ProjectReference Include="..\RewardFlow.API\RewardFlow.API.csproj" />
     </ItemGroup>
 
     <ItemGroup>
+      <Folder Include="Infrastructure\DataGenerators\Fakers\Employees\" />
+      <Folder Include="Infrastructure\DataGenerators\Fakers\Users\" />
       <Folder Include="Users\" />
     </ItemGroup>
 

--- a/src/RewardFlow.IntegrationTests/Users/GetAllUsersTests.cs
+++ b/src/RewardFlow.IntegrationTests/Users/GetAllUsersTests.cs
@@ -5,10 +5,10 @@ using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Reward_Flow_v2.User;
 using RewardFlow.IntegrationTests.Infrastructure;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators;
 using Reward_Flow_v2.User.Data;
 using RewardFlow_API.User.Data.Dtos;
 using RewardFlow.IntegrationTests.Auth.Common;
+using RewardFlow.TestUtilities.DataGenerators;
 using Xunit;
 
 namespace RewardFlow.IntegrationTests.Users;

--- a/src/RewardFlow.IntegrationTests/Users/GetUserByEmailTests.cs
+++ b/src/RewardFlow.IntegrationTests/Users/GetUserByEmailTests.cs
@@ -3,10 +3,10 @@ using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
 using RewardFlow.IntegrationTests.Infrastructure;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators;
 using Reward_Flow_v2.User;
 using Reward_Flow_v2.User.Data;
 using RewardFlow_API.User.Data.Dtos;
+using RewardFlow.TestUtilities.DataGenerators;
 using Xunit;
 
 namespace RewardFlow.IntegrationTests.Users;

--- a/src/RewardFlow.IntegrationTests/Users/GetUserByUsernameTests.cs
+++ b/src/RewardFlow.IntegrationTests/Users/GetUserByUsernameTests.cs
@@ -3,10 +3,10 @@ using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
 using RewardFlow.IntegrationTests.Infrastructure;
-using RewardFlow.IntegrationTests.Infrastructure.DataGenerators;
 using Reward_Flow_v2.User;
 using Reward_Flow_v2.User.Data;
 using RewardFlow_API.User.Data.Dtos;
+using RewardFlow.TestUtilities.DataGenerators;
 using Xunit;
 
 namespace RewardFlow.IntegrationTests.Users;


### PR DESCRIPTION
Move TestDataGenerator, EmployeeFaker, UserFaker, and related classes from IntegrationTests project to a new RewardFlow.TestUtilities project. This allows test data generation utilities to be shared across both IntegrationTests and UnitTest projects, reducing code duplication and improving maintainability.

Closes #20 