### PR TITLE
Refactor and update Jwt, refresh tokens handling and tests

### DIFF
--- a/src/RewardFlow.API/Program.cs
+++ b/src/RewardFlow.API/Program.cs
@@ -28,6 +28,7 @@ using RewardFlow_API.Rewards.Data;
 using RewardFlow_API.Common.Interface;
 using RewardFlow_API.Employees.Common;
 using RewardFlow_API.Rewards.Courses;
+using RewardFlow_API.User.AuthService;
 using Scalar.AspNetCore;
 using UserContext = RewardFlow_API.Common.Interface.UserContext;
 
@@ -61,6 +62,9 @@ public sealed class Program
         builder.Services.AddScoped<IBulkEmployeesImporter,BulkEmployeesImportJob>();
         builder.Services.AddScoped<ITokenBackgroundJob,TokenBackgroundJob>();
         builder.Services.AddScoped<IBulkInserter<EmployeeNameToken>, EmployeeTokenBulkInsert>();
+
+        builder.Services.AddSingleton(TimeProvider.System);
+        builder.Services.AddSingleton<TokenService>();
         
         // Register Interceptors
         builder.Services

--- a/src/RewardFlow.API/User/AuthService/Login/Login.cs
+++ b/src/RewardFlow.API/User/AuthService/Login/Login.cs
@@ -27,7 +27,7 @@ public static class Login
             .WithTags(AuthApiPath.Tag);
     }
 
-    private static async Task<IResult> HandlerAsync(Login.Request request, UserDbContext _dbContext, IConfiguration configuration, CancellationToken cancellationToken)
+    private static async Task<IResult> HandlerAsync(Login.Request request, TokenService tokenService, UserDbContext _dbContext, IConfiguration configuration, CancellationToken cancellationToken)
     {
         var validationResult = new LoginUserRequestValidator().Validate(request);
         
@@ -46,8 +46,8 @@ public static class Login
         if (result == PasswordVerificationResult.Failed)
             return Results.BadRequest("Invalid username or password");
 
-        var token = TokenService.CreateToken(user, configuration);
-        var refreshToken = TokenService.GenerateRefreshToken();
+        var token = tokenService.CreateToken(user);
+        var refreshToken = tokenService.GenerateRefreshToken();
         
         user.LastVisit = DateTime.UtcNow;
         user.RefreshToken = refreshToken;

--- a/src/RewardFlow.API/User/AuthService/RefreshToken.cs
+++ b/src/RewardFlow.API/User/AuthService/RefreshToken.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Reward_Flow_v2.User.Data.Database;
+using RewardFlow_API.User.AuthService;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
@@ -20,57 +21,22 @@ public static class RefreshToken
             .WithTags(AuthApiPath.Tag);
     }
 
-    private static async Task<IResult> HandlerAsync(Request request, UserDbContext _dbContext, IConfiguration configuration, CancellationToken cancellationToken)
+    private static async Task<IResult> HandlerAsync(Request request, TokenService tokenService, UserDbContext _dbContext, IConfiguration configuration, CancellationToken cancellationToken)
     {
         var user = await _dbContext.User
             .FirstOrDefaultAsync(u => u.RefreshToken == request.RefreshToken && u.RefreshTokenExpiry > DateTime.UtcNow, cancellationToken);
 
         if (user == null)
             return Results.Unauthorized();
-
-        var newJwtToken = CreateToken(user, configuration);
-        var newRefreshToken = GenerateRefreshToken();
-
-        user.RefreshToken = newRefreshToken;
-        user.RefreshTokenExpiry = DateTime.UtcNow.AddDays(7);
-        user.LastVisit = DateTime.UtcNow;
         
-        _dbContext.Update(user);
+        var newJwtToken = tokenService.CreateToken(user);
+        var newRefreshToken = tokenService.GenerateRefreshToken();
+
+        user.UpdateRefreshToken(newRefreshToken);
+        user.LastVisitedNow();
+        
         await _dbContext.SaveChangesAsync(cancellationToken);
 
         return Results.Ok(new Response(newJwtToken, newRefreshToken));
-    }
-
-    private static string CreateToken(Data.User user, IConfiguration configuration)
-    {
-        var Claims = new Claim[]
-        {
-            new Claim (ClaimTypes.NameIdentifier, user.UUID.ToString()),
-            new Claim (ClaimTypes.Name, user.Username),
-            new Claim (ClaimTypes.Role, Enum.GetName(typeof(Data.UserRoleEnum), user.RoleId)!)
-        };
-
-        var key = new SymmetricSecurityKey(
-            Encoding.UTF8.GetBytes(configuration.GetValue<string>("JWT:Token")!));
-
-        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha512);
-
-        var tokenDescripter = new JwtSecurityToken(
-            issuer: configuration.GetValue<string>("JWT:Issuer"),
-            audience: configuration.GetValue<string>("JWT:Audience"),
-            claims: Claims,
-            expires: DateTime.UtcNow.AddHours(1),
-            signingCredentials: creds
-            );
-
-        return new JwtSecurityTokenHandler().WriteToken(tokenDescripter);
-    }
-
-    private static string GenerateRefreshToken()
-    {
-        var randomBytes = new byte[32];
-        using var rng = System.Security.Cryptography.RandomNumberGenerator.Create();
-        rng.GetBytes(randomBytes);
-        return Convert.ToBase64String(randomBytes);
     }
 }

--- a/src/RewardFlow.API/User/AuthService/Register/Register.cs
+++ b/src/RewardFlow.API/User/AuthService/Register/Register.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Reward_Flow_v2.Common.EndpointValidation;
 using Reward_Flow_v2.User.Data;
 using Reward_Flow_v2.User.Data.Database;
+using RewardFlow_API.User.AuthService;
 using RewardFlow_API.User.Data.Dtos;
 
 namespace Reward_Flow_v2.User.AuthService.Register;
@@ -15,48 +17,48 @@ public static class Register
     public static void MapRegisterUser(this IEndpointRouteBuilder app)
     {
         app.MapPost(AuthApiPath.Register, HandlerAsync)
-            .Produces(StatusCodes.Status201Created)
+            .Produces<Response>(StatusCodes.Status201Created)
             .Produces(StatusCodes.Status409Conflict)
             .Produces<IEnumerable<FluentValidation.Results.ValidationFailure>>(StatusCodes.Status400BadRequest)
-            .WithTags(AuthApiPath.Tag);
+            .WithTags(AuthApiPath.Tag)
+            .Validation(new RegisterUserRequestValidator());
     }
 
     private static async Task<IResult> HandlerAsync(Request request, UserDbContext _dbContext,
+        TokenService tokenService,
         CancellationToken cancellationToken)
     {
-        var ValidateRequest = new RegisterUserRequestValidator().Validate(request);
-
-        if (!ValidateRequest.IsValid)
-            return Results.BadRequest(ValidateRequest.Errors);
-
         var IsUsernameInUse = await _dbContext.User.AnyAsync(x => x.Username == request.username);
 
         if (IsUsernameInUse)
             return Results.Conflict(request.username);
-
-        var user = PrepareNewUserObject(request.username, request.password, request.email);
+        var refreshToken = tokenService.GenerateRefreshToken();
+        var user = PrepareNewUserObject(request.username, request.password, refreshToken, request.email);
 
         try
         {
             _dbContext.User.Add(user);
             await _dbContext.SaveChangesAsync();
-
-            return Results.Created();
         }
         catch (Exception)
         {
             return Results.InternalServerError();
         }
+
+        var userDto = new UserDto(user.UUID, user.Username, user.Email, user.CreatedAt, user.IsActive);
+        var response = new Response(userDto, tokenService.CreateToken(user), refreshToken);
+
+        return Results.Created(string.Empty, response);
     }
 
-    private static Data.User PrepareNewUserObject(string username, string password, string? email)
+    private static Data.User PrepareNewUserObject(string username, string password, string refreshToken, string? email)
     {
         Data.User user = new();
 
         var passwordHash = new PasswordHasher<Data.User>()
             .HashPassword(user, password);
 
-        user.PrepareNewUser(username, passwordHash, email);
+        user.PrepareNewUser(username, passwordHash, refreshToken, email);
 
         return user;
     }

--- a/src/RewardFlow.API/User/AuthService/TokenService.cs
+++ b/src/RewardFlow.API/User/AuthService/TokenService.cs
@@ -6,9 +6,9 @@ using System.Text;
 
 namespace RewardFlow_API.User.AuthService;
 
-public static class TokenService
+public class TokenService(TimeProvider timeProvider, IConfiguration configuration)
 {
-    public static string CreateToken(Reward_Flow_v2.User.Data.User user, IConfiguration configuration)
+    public string CreateToken(Reward_Flow_v2.User.Data.User user)
     {
         var Claims = new Claim[]
         {
@@ -27,14 +27,14 @@ public static class TokenService
             issuer: configuration.GetValue<string>("JWT:Issuer"),
             audience: configuration.GetValue<string>("JWT:Audience"),
             claims: Claims,
-            expires: DateTime.UtcNow.AddHours(1),
+            expires: timeProvider.GetUtcNow().DateTime.AddMinutes(10),
             signingCredentials: creds
         );
 
         return new JwtSecurityTokenHandler().WriteToken(tokenDescripter);
     }
 
-    public static string GenerateRefreshToken()
+    public string GenerateRefreshToken()
     {
         var randomBytes = new byte[32];
         using var rng = System.Security.Cryptography.RandomNumberGenerator.Create();

--- a/src/RewardFlow.API/User/Data/Dtos/UserDto.cs
+++ b/src/RewardFlow.API/User/Data/Dtos/UserDto.cs
@@ -1,3 +1,3 @@
 namespace RewardFlow_API.User.Data.Dtos;
 
-public record UserDto(Guid UUID, string Username, string? Email, DateTime CreatedAt, DateTime? LastVisit, bool IsActive);
+public record UserDto(Guid UUID, string Username, string? Email, DateTime CreatedAt, bool IsActive);

--- a/src/RewardFlow.API/User/Data/User.cs
+++ b/src/RewardFlow.API/User/Data/User.cs
@@ -24,7 +24,7 @@ namespace Reward_Flow_v2.User.Data
         public string? RefreshToken { get; set; }
         public DateTime? RefreshTokenExpiry { get; set; }
         
-        internal void PrepareNewUser(string username, string hashedPassword, string? email)
+        internal void PrepareNewUser(string username, string hashedPassword, string refreshToken, string? email)
         {
             this.Username = username;
             this.PasswordHash = hashedPassword;
@@ -32,12 +32,25 @@ namespace Reward_Flow_v2.User.Data
 
             RoleId = ((int)UserRoleEnum.User);
             UserRole = null;
-            CreatedAt = DateTime.Now;
-            LastVisit = DateTime.Now;
+            CreatedAt = DateTime.UtcNow;
             IsActive = true;
             ProfilePictureUrl = null;
             PlanId = ((int)PlanEnum.Free);
             Plan = null;
+
+            UpdateRefreshToken(refreshToken);
+            LastVisitedNow();
+        }
+
+        internal void UpdateRefreshToken(string refreshToken)
+        {
+            RefreshToken = refreshToken;
+            RefreshTokenExpiry = DateTime.UtcNow.AddDays(7);
+        }
+
+        internal void LastVisitedNow()
+        {
+            LastVisit = DateTime.UtcNow;
         }
     }
 }

--- a/src/RewardFlow.IntegrationTests/Auth/BaseAuthTestFixture.cs
+++ b/src/RewardFlow.IntegrationTests/Auth/BaseAuthTestFixture.cs
@@ -19,9 +19,5 @@ public class BaseAuthTestFixture: IClassFixture<TestWebApplicationFactory>
         _dbUtility = new DbUtility(_factory);
     }
 
-    public async Task InitializeAsync()
-    {
-        // Initialize any common test data here if needed
-        // For example, create default roles or setup initial database state
-    }
+    public async Task InitializeAsync() => await Task.CompletedTask;
 }

--- a/src/RewardFlow.IntegrationTests/Auth/LoginTests.cs
+++ b/src/RewardFlow.IntegrationTests/Auth/LoginTests.cs
@@ -2,6 +2,7 @@ using Bogus;
 using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
+using Reward_Flow_v2.User;
 using RewardFlow.IntegrationTests.Infrastructure;
 using RewardFlow.IntegrationTests.Auth.Common;
 using Reward_Flow_v2.User.AuthService.Login;
@@ -102,5 +103,21 @@ public class LoginTests(TestWebApplicationFactory factory) : BaseAuthTestFixture
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Login_ShouldReturnAuenticationTokens()
+    {
+        // Arrange
+        var request = RequestCreator.CreateLoginRequest(_testUser, _testPassword);
+
+        // Act
+        var response = await _client.PostAsJsonAsync(AuthApiPath.Login, request);
+
+        // Assert
+        var result = await response.Content.ReadFromJsonAsync<Login.Response>();
+        result.Should().NotBeNull();
+        result.JWTToken.Should().NotBeNullOrEmpty();
+        result.RefreshToken.Should().NotBeNullOrEmpty();
     }
 }

--- a/src/RewardFlow.IntegrationTests/Auth/RefreshTokenTests.cs
+++ b/src/RewardFlow.IntegrationTests/Auth/RefreshTokenTests.cs
@@ -1,0 +1,135 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Time.Testing;
+using Reward_Flow_v2.User;
+using Reward_Flow_v2.User.AuthService;
+using Reward_Flow_v2.User.AuthService.Login;
+using Reward_Flow_v2.User.AuthService.Register;
+using RewardFlow.IntegrationTests.Infrastructure;
+using System.Net;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace RewardFlow.IntegrationTests.Auth;
+
+public class RefreshTokenTests(TestWebApplicationFactory factory) : BaseAuthTestFixture(factory), IAsyncLifetime
+{
+    private HttpClient client = default!;
+    FakeTimeProvider fakeTime;
+    private Register.Response register;
+
+    public new async Task InitializeAsync()
+    {
+        fakeTime = new FakeTimeProvider(DateTimeOffset.UtcNow);
+
+        var app = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<TimeProvider>();
+                services.AddSingleton<TimeProvider>(fakeTime);
+            });
+        });
+
+        client = app.CreateClient();
+        register = await CreateUser();
+        fakeTime.Advance(TimeSpan.FromSeconds(1));
+        await base.InitializeAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task RefreshToken_AfterJwtExpiration_ShouldReturnOk()
+    {
+        // Arrange
+        fakeTime.Advance(TimeSpan.FromMinutes(11));
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            AuthApiPath.RefreshToken, new RefreshToken.Request(register.RefreshToken));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task RefreshToken_BeforeJwtExpiration_ShouldReturnOk()
+    {
+        // Arrange
+        fakeTime.Advance(TimeSpan.FromMinutes(5));
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            AuthApiPath.RefreshToken, new RefreshToken.Request(register.RefreshToken));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task RefreshToken_ShouldIssueNewJwt()
+    {
+        // Act
+        var response = await client.PostAsJsonAsync(
+            AuthApiPath.RefreshToken, new RefreshToken.Request(register.RefreshToken));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<RefreshToken.Response>();
+
+        result!.JWTToken.Should().NotBe(register.JwtToken);
+    }
+
+    [Fact]
+    public async Task RefreshToken_ShouldRotateRefreshToken()
+    {
+        // Act
+        var response = await client.PostAsJsonAsync(
+            AuthApiPath.RefreshToken, new RefreshToken.Request(register.RefreshToken));
+        
+        // Assert
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<RefreshToken.Response>();
+
+        result!.RefreshToken.Should().NotBe(register.RefreshToken);
+    }
+
+    [Fact]
+    public async Task RefreshToken_OldRefreshToken_ShouldReturnUnauthorized()
+    {
+        // Arrange
+        var first = await client.PostAsJsonAsync(
+            AuthApiPath.RefreshToken,
+            new RefreshToken.Request(register.RefreshToken));
+
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Act
+        var second = await client.PostAsJsonAsync(
+            AuthApiPath.RefreshToken,
+            new RefreshToken.Request(register.RefreshToken));
+
+        // Assert
+        second.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+
+    private async Task<Register.Response> CreateUser()
+    {
+        const string failMessage = "Failed at created user arrangement";
+
+        var request = new Register.Request(_faker.Internet.UserName(), _faker.Internet.Password(),
+            _faker.Internet.Email());
+        var httpResponseMessage = await client.PostAsJsonAsync(AuthApiPath.Register, request);
+        httpResponseMessage.StatusCode.Should().Be(HttpStatusCode.Created, failMessage);
+
+        var result = await httpResponseMessage.Content.ReadFromJsonAsync<Register.Response>();
+        result.Should().NotBeNull(failMessage);
+
+        return result;
+    }
+}

--- a/src/RewardFlow.IntegrationTests/Auth/RegisterTests.cs
+++ b/src/RewardFlow.IntegrationTests/Auth/RegisterTests.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Reward_Flow_v2.User;
 using RewardFlow.IntegrationTests.Infrastructure;
 using RewardFlow.IntegrationTests.Auth.Common;
 using Reward_Flow_v2.User.AuthService.Register;
@@ -36,7 +37,7 @@ public class RegisterTests(TestWebApplicationFactory factory) : BaseAuthTestFixt
         var request = RequestCreator.CreateRegisterRequest(userData, password);
 
         // Act
-        var response = await _client.PostAsJsonAsync("/api/Auth/Register", request);
+        var response = await _client.PostAsJsonAsync(AuthApiPath.Register, request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);

--- a/src/RewardFlow.IntegrationTests/Infrastructure/UserClient.cs
+++ b/src/RewardFlow.IntegrationTests/Infrastructure/UserClient.cs
@@ -3,6 +3,7 @@ using RewardFlow_API.User.AuthService;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
@@ -47,7 +48,9 @@ public class UserClient
     
     public void Authanticate()
     {
-        var jwtToken = TokenService.CreateToken(User, _factory.Configuration);
+        var tokenService =  _factory.Services.GetRequiredService<TokenService>();
+        
+        var jwtToken = tokenService.CreateToken(User);
         Client.DefaultRequestHeaders.Authorization =
         new AuthenticationHeaderValue("Bearer", jwtToken);
     }

--- a/src/RewardFlow.IntegrationTests/RewardFlow.IntegrationTests.csproj
+++ b/src/RewardFlow.IntegrationTests/RewardFlow.IntegrationTests.csproj
@@ -16,6 +16,7 @@
       <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.7" />
+      <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
       <PackageReference Include="Respawn" Version="7.0.0" />
       <PackageReference Include="Testcontainers" Version="4.9.0" />


### PR DESCRIPTION
- Refactor TokenService from static helper to DI singleton with TimeProvider for testable token expiry
- Remove duplicate JWT/refresh token logic from RefreshToken.cs, fixing missing TenantId claim in refresh-issued tokens
- Issue and persist refresh tokens on registration and return tokens from the register endpoint
- Shorten JWT lifetime to 10 minutes; use UTC consistently in User entity
- Add integration tests for refresh token rotation, expiry, and replay rejection using FakeTimeProvider